### PR TITLE
Use rustfmt for formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # will have compiled files and executables
 /rs/target/
 
+# cargo fmt backup files
+*.bk
+
 # I don’t want anybody even trying with any of Nintendo’s copyrights
 *.smc
 *.sfc

--- a/rs/rustfmt.toml
+++ b/rs/rustfmt.toml
@@ -1,0 +1,1 @@
+hard_tabs = true

--- a/rs/src/desclist.rs
+++ b/rs/src/desclist.rs
@@ -18,13 +18,10 @@ pub fn write_desclist(f: &mut File, cfgs: &Vec<spritecfg::SpriteCfg>) {
 			byte0,
 			byte1,
 			cfg.desc(false),
-		).unwrap();
+		)
+			.unwrap();
 
-		writeln!(f, "{:02x}\t{:02x}\t{}",
-			byte0,
-			m16byte,
-			"0,0,0000 4,4,010a"
-		).unwrap();
+		writeln!(f, "{:02x}\t{:02x}\t{}", byte0, m16byte, "0,0,0000 4,4,010a").unwrap();
 
 		let byte1_s = byte1 | 0x10;
 		let m16byte_s = m16byte | 0x10;
@@ -32,14 +29,16 @@ pub fn write_desclist(f: &mut File, cfgs: &Vec<spritecfg::SpriteCfg>) {
 			byte0,
 			byte1_s,
 			cfg.desc(true),
-		).unwrap();
+		)
+			.unwrap();
 
-		writeln!(f, "{:02x}\t{:02x}\t{}",
-			byte0,
-			m16byte_s,
-			"0,0,0000 3,4,010c, 6,4,010a"
-		).unwrap();
-	};
+		writeln!(f,
+		         "{:02x}\t{:02x}\t{}",
+		         byte0,
+		         m16byte_s,
+		         "0,0,0000 3,4,010c, 6,4,010a")
+			.unwrap();
+	}
 }
 
 pub fn write_collection(mwt: &mut File, mw2: &mut File, cfgs: &Vec<spritecfg::SpriteCfg>) {
@@ -52,7 +51,7 @@ pub fn write_collection(mwt: &mut File, mw2: &mut File, cfgs: &Vec<spritecfg::Sp
 			cfg.place_mw2(&mut bytes, true);
 			writeln!(mwt, "\t{}", cfg.name(true)).unwrap();
 		};
-	};
+	}
 	bytes.push(0xff);
 
 	mw2.write_all(&bytes);

--- a/rs/src/dys_tables.rs
+++ b/rs/src/dys_tables.rs
@@ -1,11 +1,11 @@
 #[derive(Debug)]
 pub struct DysTables {
-pub sprite_sizes: usize,
-pub storage_ptrs: usize,
-pub option_bytes: usize,
-pub init_ptrs:    usize,
-pub main_ptrs:    usize,
-pub cls_ptrs:     usize,
-pub xsp_ptrs:     usize,
-pub mxs_ptrs:     usize,
+	pub sprite_sizes: usize,
+	pub storage_ptrs: usize,
+	pub option_bytes: usize,
+	pub init_ptrs: usize,
+	pub main_ptrs: usize,
+	pub cls_ptrs: usize,
+	pub xsp_ptrs: usize,
+	pub mxs_ptrs: usize,
 }

--- a/rs/src/genus.rs
+++ b/rs/src/genus.rs
@@ -44,13 +44,13 @@ impl Genus {
 
 	pub fn from_str(name: &str) -> Result<Genus, String> {
 		match name {
-			"standard"  => Ok(Genus::Std),
-			"shooter"   => Ok(Genus::Sht),
+			"standard" => Ok(Genus::Std),
+			"shooter" => Ok(Genus::Sht),
 			"generator" => Ok(Genus::Gen),
-			"run-once"  => Ok(Genus::R1s),
-			"cluster"   => Ok(Genus::Cls),
-			"scroll"    => Ok(Genus::Scl),
-			_           => Err(String::from("Bad sprite type")),
+			"run-once" => Ok(Genus::R1s),
+			"cluster" => Ok(Genus::Cls),
+			"scroll" => Ok(Genus::Scl),
+			_ => Err(String::from("Bad sprite type")),
 		}
 	}
 

--- a/rs/src/insertlist.rs
+++ b/rs/src/insertlist.rs
@@ -1,7 +1,7 @@
 use nom::*;
-use parse_aux::{dys_prefix};
+use parse_aux::dys_prefix;
 use std::collections::HashMap;
-use std::path::{Path,PathBuf};
+use std::path::{Path, PathBuf};
 use genus::*;
 
 pub type InsertList = HashMap<Genus, Vec<(u32, PathBuf)>>;
@@ -15,7 +15,7 @@ pub fn parse_list(list: &str) -> Result<InsertList, String> {
 		}
 	} else {
 		parse_oldstyle(list)
-		//Err(String::from("That isn't real"))
+		// Err(String::from("That isn't real"))
 	}
 }
 
@@ -43,7 +43,7 @@ fn parse_newstyle(list: &str) -> Result<HashMap<Genus, Vec<(u32, PathBuf)>>, Str
 		} else {
 			return Err(format!("cannot start a command with '{}'", first));
 		};
-	};
+	}
 
 	Ok(hm)
 }
@@ -51,7 +51,7 @@ fn parse_newstyle(list: &str) -> Result<HashMap<Genus, Vec<(u32, PathBuf)>>, Str
 fn sprite_line(line: &str) -> Result<(u32, PathBuf), String> {
 	let mut parts = line.splitn(2, char::is_whitespace);
 	let (num_s, path_s) = match (parts.next(), parts.next()) {
-		(Some(s0), Some(s1)) => (s0,s1),
+		(Some(s0), Some(s1)) => (s0, s1),
 		_ => return Err(String::from("# needs a sprite number and path")),
 	};
 

--- a/rs/src/main.rs
+++ b/rs/src/main.rs
@@ -1,12 +1,13 @@
-//extern crate libc;
-#[macro_use] extern crate nom;
+// extern crate libc;
+#[macro_use]
+extern crate nom;
 extern crate asar;
 extern crate rand;
 use std::collections::{HashSet, HashMap};
 use std::env;
 use std::io::prelude::*;
 use std::fs::{read_dir, File, OpenOptions};
-use std::path::{Path,PathBuf};
+use std::path::{Path, PathBuf};
 use rand::random;
 
 mod genus;
@@ -48,7 +49,7 @@ fn main() {
 
 	for flag in args.flags {
 		println!("ran with -{}", flag);
-	};
+	}
 
 	if !asar::init() {
 		error_exit!("No asar, why, what");
@@ -64,7 +65,7 @@ fn main() {
 		Err(e) => {
 			println!("Couldn't open ROM ({}): {}", rom_path.display(), e);
 			return;
-		},
+		}
 	};
 
 	let mut insert_list = match File::open(&list_path) {
@@ -72,7 +73,7 @@ fn main() {
 		Err(e) => {
 			println!("Couldn't open insert list ({}): {}", list_path.display(), e);
 			return;
-		},
+		}
 	};
 
 	let mut list_buf = String::new();
@@ -81,13 +82,18 @@ fn main() {
 
 	let space_freed = free_tool_space(&mut rom);
 
-	println!("Freed {} kilobytes of space from previous runs.", space_freed / 1024);
+	println!("Freed {} kilobytes of space from previous runs.",
+	         space_freed / 1024);
 
 	let patch_dir = base_dir.join("patch");
 
-	if let Err((es,ws)) = patch_subroutines(&mut rom, &patch_dir, &base_dir) {
-		for e in es { println!("SUB: {}", e); };
-		for w in ws { println!("SUB: {}", w); };
+	if let Err((es, ws)) = patch_subroutines(&mut rom, &patch_dir, &base_dir) {
+		for e in es {
+			println!("SUB: {}", e);
+		}
+		for w in ws {
+			println!("SUB: {}", w);
+		}
 		return;
 	};
 	println!("Inserted subroutines");
@@ -95,18 +101,24 @@ fn main() {
 	let patch_path = patch_dir.join("daiyousei.asm");
 	match asar::patch(&patch_path, &mut rom) {
 		Ok((_, warns)) => {
-			for warn in warns { println!("Warning: {}", warn) };
-		},
+			for warn in warns {
+				println!("Warning: {}", warn)
+			}
+		}
 		Err((errors, warns)) => {
-			for error in errors { println!("{}", error) };
-			for warn in warns { println!("{}", warn) };
+			for error in errors {
+				println!("{}", error)
+			}
+			for warn in warns {
+				println!("{}", warn)
+			}
 			return;
-		},
+		}
 	};
 
 	for line in asar::prints().into_iter() {
 		println!("Main patch: {}", line);
-	};
+	}
 
 	let dys_data = get_tables().unwrap();
 	copy_sprite_settings(&mut rom, dys_data.option_bytes);
@@ -118,10 +130,14 @@ fn main() {
 	match insert_sprites(&mut rom, &cfgs, &patch_dir, &dys_data, verbose) {
 		Err((errs, warns)) => {
 			println!("==== Insertion was stopped by an error ====");
-			for err in errs { println!("Error: {}", err); };
-			for warn in warns { println!("Warning: {}", warn); };
+			for err in errs {
+				println!("Error: {}", err);
+			}
+			for warn in warns {
+				println!("Warning: {}", warn);
+			}
 			return;
-		},
+		}
 		_ => (),
 	};
 
@@ -180,8 +196,9 @@ fn parse_args(argv: env::Args) -> Result<CmdArgs, String> {
 	}
 }
 
-fn get_cfgs(insert_list: insertlist::InsertList, base_dir: &PathBuf)
--> Result<Vec<SpriteCfg>, String> {
+fn get_cfgs(insert_list: insertlist::InsertList,
+            base_dir: &PathBuf)
+            -> Result<Vec<SpriteCfg>, String> {
 	let mut cfgs = Vec::<SpriteCfg>::new();
 
 	for (gen, sprites) in insert_list.iter() {
@@ -203,10 +220,10 @@ fn get_cfgs(insert_list: insertlist::InsertList, base_dir: &PathBuf)
 
 			match SpriteCfg::parse(&full_path, *gen, id as u16, &cfg_buf) {
 				Ok(cfg) => cfgs.push(cfg),
-				Err(e)  => return Err(format!("{}: {:?}", full_path.display(), e)),
+				Err(e) => return Err(format!("{}: {:?}", full_path.display(), e)),
 			}
-		};
-	};
+		}
+	}
 
 	Ok(cfgs)
 }
@@ -233,10 +250,11 @@ fn patch_subroutines(rom: &mut RomBuf, patch_dir: &Path, base_dir: &Path) -> asa
 	for print in asar::prints() {
 		ptrf.write_all(print.as_bytes()).unwrap();
 		ptrf.write_all(b"\r\n").unwrap();
-	};
+	}
 	ptrf.sync_all().unwrap();
 
-	let mut usrf = match OpenOptions::new().write(true)
+	let mut usrf = match OpenOptions::new()
+		.write(true)
 		.truncate(true)
 		.create(true)
 		.open(&usrf_path) {
@@ -253,23 +271,25 @@ fn patch_subroutines(rom: &mut RomBuf, patch_dir: &Path, base_dir: &Path) -> asa
 			let p = entry.unwrap().path();
 			if p.extension() == Some(&std::ffi::OsString::from("asm")) {
 				println!("Subroutines in [{}] [DYS_AUTOSPACE_{:08X}]",
-					p.to_string_lossy(), namespace_id);
+				         p.to_string_lossy(),
+				         namespace_id);
 				let mut f = File::open(p).unwrap();
 				let mut usr_buf = Vec::new();
 				f.read_to_end(&mut usr_buf).unwrap();
-				usrf.write_all(format!("\r\nnamespace DYS_AUTOSPACE_{:08X}\r\n",
-					namespace_id).as_bytes()).unwrap();
+				usrf.write_all(format!("\r\nnamespace DYS_AUTOSPACE_{:08X}\r\n", namespace_id)
+						.as_bytes())
+					.unwrap();
 				usrf.write_all(&usr_buf).unwrap();
 				namespace_id += 1;
 			};
-		};
+		}
 
 		try!(asar::patch(&usrf_path, rom));
 
 		for print in asar::prints() {
 			ptrf.write_all(print.as_bytes()).unwrap();
 			ptrf.write_all(b"\r\n").unwrap();
-		};
+		}
 
 		ptrf.sync_all().unwrap();
 	};
@@ -277,9 +297,12 @@ fn patch_subroutines(rom: &mut RomBuf, patch_dir: &Path, base_dir: &Path) -> asa
 	Ok(((), vec![]))
 }
 
-fn insert_sprites(rom: &mut RomBuf, cfgs: &Vec<SpriteCfg>, patch_dir: &Path, dys_data: &DysTables,
-verbose: bool)
--> asar::AResult<()> {
+fn insert_sprites(rom: &mut RomBuf,
+                  cfgs: &Vec<SpriteCfg>,
+                  patch_dir: &Path,
+                  dys_data: &DysTables,
+                  verbose: bool)
+                  -> asar::AResult<()> {
 	let mut routines = HashMap::<PathBuf, InsertPoint>::new();
 	let prelude = "incsrc \"sprite_prelude.asm\"\r\n";
 	let temploc = patch_dir.join("temp_sprite.asm");
@@ -289,13 +312,17 @@ verbose: bool)
 		let (ip, warns) = if routines.contains_key(src) {
 			let ip = *routines.get(src).unwrap();
 			println!("Inserting {} #{:03x} [{}] (repeat)",
-				cfg.genus.shortname(), cfg.id, src.to_string_lossy());
+			         cfg.genus.shortname(),
+			         cfg.id,
+			         src.to_string_lossy());
 			cfg.apply_cfg(rom, dys_data);
 			cfg.apply_offsets(rom, dys_data, ip);
 			(ip, vec![])
 		} else {
 			println!("Inserting {} #{:03x} [{}]",
-				cfg.genus.shortname(), cfg.id, src.to_string_lossy());
+			         cfg.genus.shortname(),
+			         cfg.id,
+			         src.to_string_lossy());
 			let (ip, warns) = try!(cfg.assemble(rom, prelude, src, &temploc));
 			cfg.apply_cfg(rom, dys_data);
 			cfg.apply_offsets(rom, dys_data, ip);
@@ -307,9 +334,9 @@ verbose: bool)
 			print!("\tMAIN: ${:06x}\n\tINIT: ${:06x}\n", ip.main, ip.init);
 			for warn in warns {
 				println!("\tWarning: {}", warn);
-			};
+			}
 		};
-	};
+	}
 
 	Ok(((), vec![]))
 }
@@ -319,18 +346,18 @@ fn get_tables() -> Result<DysTables, String> {
 		sprite_sizes: try!(possible_label("DYS_DATA_SPRITE_SIZES")),
 		storage_ptrs: try!(possible_label("DYS_DATA_STORAGE_PTRS")),
 		option_bytes: try!(possible_label("DYS_DATA_OPTION_BYTES")),
-		init_ptrs:    try!(possible_label("DYS_DATA_INIT_PTRS")),
-		main_ptrs:    try!(possible_label("DYS_DATA_MAIN_PTRS")),
-		cls_ptrs:     try!(possible_label("DYS_DATA_CLS_PTRS")),
-		xsp_ptrs:     try!(possible_label("DYS_DATA_XSP_PTRS")),
-		mxs_ptrs:     try!(possible_label("DYS_DATA_MXS_PTRS")),
+		init_ptrs: try!(possible_label("DYS_DATA_INIT_PTRS")),
+		main_ptrs: try!(possible_label("DYS_DATA_MAIN_PTRS")),
+		cls_ptrs: try!(possible_label("DYS_DATA_CLS_PTRS")),
+		xsp_ptrs: try!(possible_label("DYS_DATA_XSP_PTRS")),
+		mxs_ptrs: try!(possible_label("DYS_DATA_MXS_PTRS")),
 	})
 }
 
 fn possible_label(name: &str) -> Result<usize, String> {
 	match asar::label(name) {
 		Some(v) => Ok(v),
-		None    => Err(format!("Missing label: {}", name)),
+		None => Err(format!("Missing label: {}", name)),
 	}
 }
 
@@ -343,7 +370,7 @@ fn free_tool_space(rom: &mut RomBuf) -> usize {
 		if eq_str_bytes("STAR", &rom.buf[i..]) {
 			// the length restriction on this loop
 			// lets us know these won’t fail.
-			let len  = rom.get_word(rom.unmap(i + 4).unwrap()).unwrap();
+			let len = rom.get_word(rom.unmap(i + 4).unwrap()).unwrap();
 			let nlen = rom.get_word(rom.unmap(i + 6).unwrap()).unwrap();
 			if len == nlen ^ 0xffff {
 				let len = if len == 0 { 0x1_0000 } else { len + 1 };
@@ -353,9 +380,8 @@ fn free_tool_space(rom: &mut RomBuf) -> usize {
 					reverted_mdk = true;
 				}
 
-				if len > 3
-				&& eq_str_bytes("DYS", &rom.buf[i + 8..])
-				|| eq_str_bytes("MDK", &rom.buf[i + 8..]) {
+				if len > 3 && eq_str_bytes("DYS", &rom.buf[i + 8..]) ||
+				   eq_str_bytes("MDK", &rom.buf[i + 8..]) {
 					let addr = rom.unmap(i).unwrap();
 					rom.clear_bytes(addr, len + 8).unwrap();
 					cleared_bytes += len + 8;
@@ -375,26 +401,27 @@ fn free_tool_space(rom: &mut RomBuf) -> usize {
 }
 
 fn revert_mdk(rom: &mut RomBuf) {
-		rom.set_bytes(0x008127, &[0xbd, 0xc8, 0x14, 0xf0]).unwrap();
-		rom.set_bytes(0x008151, &[0xa9, 0xff, 0x9d, 0x1a, 0x16]).unwrap();
-		rom.set_bytes(0x008172, &[0xa9, 0x08, 0x9d, 0xc8, 0x14]).unwrap();
-		rom.set_bytes(0x0082b3, &[0xa7, 0x87]).unwrap();
-		rom.set_bytes(0x0085c3, &[0x9c, 0x91, 0x14, 0xb5, 0x9e]).unwrap();
-		rom.set_bytes(0x0087a7, &[0x22, 0x59, 0xda, 0x2]).unwrap();
-		rom.set_bytes(0x00c089, &[0xbd, 0xd4, 0x14, 0x9d, 0x7b,
-								  0x18, 0x29, 0x01, 0x9d, 0xd4, 0x14]).unwrap();
-		rom.set_bytes(0x00c4cb, &[0xc9, 0x21, 0xd0, 0x69]).unwrap();
-		rom.set_bytes(0x00c6d6, &[0xaa, 0xbd, 0x09, 0xc6]).unwrap();
-		rom.set_bytes(0x00d43e, &[0x9e, 0xc8, 0x14, 0x60]).unwrap();
-		rom.set_bytes(0x01a866, &[0xc9, 0xe7, 0x90, 0x22]).unwrap();
-		rom.set_bytes(0x01a94b, &[0x29, 0x0d, 0x9d, 0xe0, 0x14]).unwrap();
-		rom.set_bytes(0x01a963, &[0x29, 0x0d, 0x9d, 0xd4, 0x14]).unwrap();
-		rom.set_bytes(0x01a9a6, &[0xaa, 0xbf, 0x59, 0xf6, 0x07]).unwrap();
-		rom.set_bytes(0x01a9c9, &[0x22, 0xd2, 0xf7, 0x07]).unwrap();
-		rom.set_bytes(0x01aba0, &[0xa5, 0x04, 0x38, 0xe9, 0xc8]).unwrap();
-		rom.set_bytes(0x01affe, &[0xad, 0xb9, 0x18, 0xf0, 0x27]).unwrap();
-		rom.set_bytes(0x01b395, &[0xbc, 0xab, 0x17, 0xf0, 0x0a]).unwrap();
-		rom.set_bytes(0x07f785, &[0xa9, 0x01, 0x9d, 0xa0, 0x15]).unwrap();
+	rom.set_bytes(0x008127, &[0xbd, 0xc8, 0x14, 0xf0]).unwrap();
+	rom.set_bytes(0x008151, &[0xa9, 0xff, 0x9d, 0x1a, 0x16]).unwrap();
+	rom.set_bytes(0x008172, &[0xa9, 0x08, 0x9d, 0xc8, 0x14]).unwrap();
+	rom.set_bytes(0x0082b3, &[0xa7, 0x87]).unwrap();
+	rom.set_bytes(0x0085c3, &[0x9c, 0x91, 0x14, 0xb5, 0x9e]).unwrap();
+	rom.set_bytes(0x0087a7, &[0x22, 0x59, 0xda, 0x2]).unwrap();
+	rom.set_bytes(0x00c089,
+		           &[0xbd, 0xd4, 0x14, 0x9d, 0x7b, 0x18, 0x29, 0x01, 0x9d, 0xd4, 0x14])
+		.unwrap();
+	rom.set_bytes(0x00c4cb, &[0xc9, 0x21, 0xd0, 0x69]).unwrap();
+	rom.set_bytes(0x00c6d6, &[0xaa, 0xbd, 0x09, 0xc6]).unwrap();
+	rom.set_bytes(0x00d43e, &[0x9e, 0xc8, 0x14, 0x60]).unwrap();
+	rom.set_bytes(0x01a866, &[0xc9, 0xe7, 0x90, 0x22]).unwrap();
+	rom.set_bytes(0x01a94b, &[0x29, 0x0d, 0x9d, 0xe0, 0x14]).unwrap();
+	rom.set_bytes(0x01a963, &[0x29, 0x0d, 0x9d, 0xd4, 0x14]).unwrap();
+	rom.set_bytes(0x01a9a6, &[0xaa, 0xbf, 0x59, 0xf6, 0x07]).unwrap();
+	rom.set_bytes(0x01a9c9, &[0x22, 0xd2, 0xf7, 0x07]).unwrap();
+	rom.set_bytes(0x01aba0, &[0xa5, 0x04, 0x38, 0xe9, 0xc8]).unwrap();
+	rom.set_bytes(0x01affe, &[0xad, 0xb9, 0x18, 0xf0, 0x27]).unwrap();
+	rom.set_bytes(0x01b395, &[0xbc, 0xab, 0x17, 0xf0, 0x0a]).unwrap();
+	rom.set_bytes(0x07f785, &[0xa9, 0x01, 0x9d, 0xa0, 0x15]).unwrap();
 }
 
 fn eq_str_bytes(s: &str, bytes: &[u8]) -> bool {
@@ -406,19 +433,37 @@ fn copy_sprite_settings(rom: &mut RomBuf, table: usize) {
 
 	rom.clear_bytes(table, 0xc8 * 16).unwrap();
 
-	for i in 0 .. 0xc8 {
+	for i in 0..0xc8 {
 		rom.set_byte(table + i * 16 + 1, i as u8).unwrap();
 		// This looks ridiculous because it is.
-		for j in 0 .. 6 {
+		for j in 0..6 {
 			let b = rom.get_byte(orig_table + i + 0xc9 * j).unwrap();
 			rom.set_byte(table + i * 16 + 2 + j, b).unwrap();
 		}
 	}
 	// + 1 is to make it inclusive.
-	for i in 0x0c9 .. 0x0ca + 1 { rom.set_byte(table + i * 16, 3).unwrap(); } // shooters
-	for i in 0x0cb .. 0x0d9 + 1 { rom.set_byte(table + i * 16, 2).unwrap(); } // generators
-	for i in 0x0da .. 0x0e0 + 1 { rom.set_byte(table + i * 16, 4).unwrap(); } // r1s
-	for i in 0x0e1 .. 0x0e6 + 1 { rom.set_byte(table + i * 16, 4).unwrap(); } // cluster r1s
-	for i in 0x0e7 .. 0x0f5 + 1 { rom.set_byte(table + i * 16, 5).unwrap(); } // scroll clear
-	for i in 0x1e7 .. 0x1f5 + 1 { rom.set_byte(table + i * 16, 5).unwrap(); } // scroll set
+	// shooters
+	for i in 0x0c9..0x0ca + 1 {
+		rom.set_byte(table + i * 16, 3).unwrap();
+	}
+	// generators
+	for i in 0x0cb..0x0d9 + 1 {
+		rom.set_byte(table + i * 16, 2).unwrap();
+	}
+	// r1s
+	for i in 0x0da..0x0e0 + 1 {
+		rom.set_byte(table + i * 16, 4).unwrap();
+	}
+	// cluster r1s
+	for i in 0x0e1..0x0e6 + 1 {
+		rom.set_byte(table + i * 16, 4).unwrap();
+	}
+	// scroll clear
+	for i in 0x0e7..0x0f5 + 1 {
+		rom.set_byte(table + i * 16, 5).unwrap();
+	}
+	// scroll set
+	for i in 0x1e7..0x1f5 + 1 {
+		rom.set_byte(table + i * 16, 5).unwrap();
+	}
 }

--- a/rs/src/spritecfg.rs
+++ b/rs/src/spritecfg.rs
@@ -18,11 +18,11 @@ pub struct CfgErr {
 
 #[derive(Debug)]
 pub struct SpriteCfg {
-pub genus: Genus,
-pub id: u16,
-pub tweak_bytes: [u8; 6],
-pub prop_bytes: [u8; 2],
-pub clipping: [u8; 4],
+	pub genus: Genus,
+	pub id: u16,
+	pub tweak_bytes: [u8; 6],
+	pub prop_bytes: [u8; 2],
+	pub clipping: [u8; 4],
 	dys_option_bytes: [u8; 2],
 	acts_like: u8,
 	extra_bytes: u8,
@@ -55,33 +55,39 @@ impl SpriteCfg {
 
 	pub fn new() -> SpriteCfg {
 		SpriteCfg {
-			genus:            Genus::Std,
-			id:               0,
-			tweak_bytes:      [0, 0, 0, 0, 0, 0],
-			prop_bytes:       [0, 0],
-			clipping:         [0, 0, 0, 0],
+			genus: Genus::Std,
+			id: 0,
+			tweak_bytes: [0, 0, 0, 0, 0, 0],
+			prop_bytes: [0, 0],
+			clipping: [0, 0, 0, 0],
 			dys_option_bytes: [0, 0],
-			acts_like:        0,
-			extra_bytes:      0,
-			name:             "".to_string(),
-			desc:             "".to_string(),
-			name_set:         None,
-			desc_set:         None,
-			source_path:      PathBuf::from(""),
+			acts_like: 0,
+			extra_bytes: 0,
+			name: "".to_string(),
+			desc: "".to_string(),
+			name_set: None,
+			desc_set: None,
+			source_path: PathBuf::from(""),
 		}
 	}
 
 	pub fn needs_init(&self) -> bool {
 		match self.genus {
 			Genus::Std => true,
-			_          => false,
+			_ => false,
 		}
 	}
 
-	pub fn placeable(&self) -> bool { self.genus.placeable() }
+	pub fn placeable(&self) -> bool {
+		self.genus.placeable()
+	}
 
-	pub fn assemble(&self, rom: &mut RomBuf, prelude: &str, source: &Path, temp: &Path)
-	-> asar::AResult<InsertPoint> {
+	pub fn assemble(&self,
+	                rom: &mut RomBuf,
+	                prelude: &str,
+	                source: &Path,
+	                temp: &Path)
+	                -> asar::AResult<InsertPoint> {
 		let (mut main, mut init) = (0usize, 0usize);
 		let warns;
 
@@ -97,12 +103,12 @@ impl SpriteCfg {
 
 		let mut srcf = match File::open(source) {
 			Ok(f) => f,
-			Err(e) => return Err((
-				vec![asar::AsmError::Interface(format!("error opening \"{}\": {}",
-					source.to_string_lossy(), e)
-				)],
-				vec![]
-			)),
+			Err(e) => {
+				return Err((vec![asar::AsmError::Interface(format!("error opening \"{}\": {}",
+				                                                   source.to_string_lossy(),
+				                                                   e))],
+				            vec![]))
+			}
 		};
 
 		srcf.read_to_end(&mut source_buf).unwrap();
@@ -111,8 +117,8 @@ impl SpriteCfg {
 		drop(tempasm);
 
 		warns = match asar::patch(temp, rom) {
-			Ok((_, ws))     => ws,
-			Err(ews)        => return Err(ews),
+			Ok((_, ws)) => ws,
+			Err(ews) => return Err(ews),
 		};
 
 		for print in asar::prints() {
@@ -120,32 +126,37 @@ impl SpriteCfg {
 			let fst = chunks.next();
 			let snd = chunks.next();
 			match fst {
-				Some("MAIN") => match snd {
-					Some(ofs) => main = usize::from_str_radix(ofs, 16).unwrap(),
-					_         => return Err((vec![],vec![])),
-				},
-				Some("INIT") => match snd {
-					Some(ofs) => init = usize::from_str_radix(ofs, 16).unwrap(),
-					_         => return Err((vec![],vec![])),
-				},
-				None         => (),
-				_            => return Err((vec![],vec![])),
+				Some("MAIN") => {
+					match snd {
+						Some(ofs) => main = usize::from_str_radix(ofs, 16).unwrap(),
+						_ => return Err((vec![], vec![])),
+					}
+				}
+				Some("INIT") => {
+					match snd {
+						Some(ofs) => init = usize::from_str_radix(ofs, 16).unwrap(),
+						_ => return Err((vec![], vec![])),
+					}
+				}
+				None => (),
+				_ => return Err((vec![], vec![])),
 			}
-		};
-
-		if main == 0 || (init == 0 && self.needs_init()) {
-			return Err((vec![],vec![]));
 		}
 
-		Ok((InsertPoint { main: main, init: init }, warns))
+		if main == 0 || (init == 0 && self.needs_init()) {
+			return Err((vec![], vec![]));
+		}
+
+		Ok((InsertPoint {
+			    main: main,
+			    init: init,
+		    },
+		    warns))
 	}
 
 	pub fn apply_cfg(&self, rom: &mut RomBuf, tables: &DysTables) {
 		match self.genus {
-			Genus::Std
-			| Genus::Gen
-			| Genus::Sht
-			| Genus::R1s => {
+			Genus::Std | Genus::Gen | Genus::Sht | Genus::R1s => {
 				if self.id < 0x200 {
 					let size_ofs = if self.id < 0x100 {
 						self.id as usize
@@ -164,9 +175,9 @@ impl SpriteCfg {
 					rom.set_bytes(optbase + 14, &self.prop_bytes).unwrap();
 					rom.set_bytes(optbase + 10, &self.clipping).unwrap();
 				};
-			},
-			Genus::Cls => {},
-			_            => unimplemented!(),
+			}
+			Genus::Cls => {}
+			_ => unimplemented!(),
 		};
 	}
 
@@ -176,7 +187,7 @@ impl SpriteCfg {
 			g if g.placeable() => {
 				rom.set_long(tables.main_ptrs + ofs, ip.main as u32).unwrap();
 				rom.set_long(tables.init_ptrs + ofs, ip.init as u32).unwrap();
-			},
+			}
 			Genus::Cls => rom.set_long(tables.cls_ptrs + ofs, ip.main as u32).unwrap(),
 			_ => unimplemented!(),
 		};
@@ -198,14 +209,18 @@ impl SpriteCfg {
 		}
 	}
 
-	pub fn uses_ebit(&self) -> bool { self.name_set.is_some() }
+	pub fn uses_ebit(&self) -> bool {
+		self.name_set.is_some()
+	}
 
 	pub fn place_mw2(&self, target: &mut Vec<u8>, ebit: bool) {
-		if !self.placeable() { panic!("Attempted to place unplaceable sprite") };
+		if !self.placeable() {
+			panic!("Attempted to place unplaceable sprite")
+		};
 		let b0 = 0x89;
 		let b1 = 0x80;
-		let num_extra_bit: u8   = if self.id & 0x100 == 0 { 0 } else { 8 };
-		let ebit_val: u8        =                if !ebit { 0 } else { 4 };
+		let num_extra_bit: u8 = if self.id & 0x100 == 0 { 0 } else { 8 };
+		let ebit_val: u8 = if !ebit { 0 } else { 4 };
 
 		let b0 = b0 | num_extra_bit | ebit_val;
 
@@ -217,12 +232,17 @@ impl SpriteCfg {
 		}
 		target.push((self.id & 0xff) as u8);
 
-		for _ in 0 .. self.extra_bytes { target.push(0); };
+		for _ in 0..self.extra_bytes {
+			target.push(0);
+		}
 	}
 
-	pub fn dys_option_bytes<'a>(&'a self) -> &'a [u8] { &self.dys_option_bytes }
-	pub fn source_path<'a>(&'a self) -> &'a PathBuf { &self.source_path }
-
+	pub fn dys_option_bytes<'a>(&'a self) -> &'a [u8] {
+		&self.dys_option_bytes
+	}
+	pub fn source_path<'a>(&'a self) -> &'a PathBuf {
+		&self.source_path
+	}
 }
 
 fn default_name(path: &Path, gen: Genus, id: u16) -> (String, String) {
@@ -236,28 +256,32 @@ fn default_name(path: &Path, gen: Genus, id: u16) -> (String, String) {
 fn parse_newstyle(path: &Path, gen: Genus, id: u16, buf: &str) -> Result<SpriteCfg, CfgErr> {
 	let (mut got_name, mut got_desc): (Option<String>, Option<String>) = (None, None);
 
-	let mut cfg = SpriteCfg { genus: gen, id: id, .. SpriteCfg::new() };
+	let mut cfg = SpriteCfg {
+		genus: gen,
+		id: id,
+		..SpriteCfg::new()
+	};
 	let mut buf = buf;
 	while let IResult::Done(rest, (name, value)) = cfg_line(buf) {
 		buf = rest;
 		match name {
-			"acts-like"    => cfg.acts_like = try!(read_byte(value)),
-			"source"       => cfg.source_path = path.with_file_name(value),
-			"props"        => try!(read_bytes(value, &mut cfg.tweak_bytes)),
-			"xbytes"       => cfg.extra_bytes = try!(read_byte(value)),
-			"ext-props"    => try!(read_bytes(value, &mut cfg.prop_bytes)),
-			"dys-opts"     => try!(read_bytes(value, &mut cfg.dys_option_bytes)),
-			"ext-clip"     => try!(read_bytes(value, &mut cfg.clipping)),
-			"name"         => got_name = Some(String::from(value)),
-			"description"  => got_desc = Some(String::from(value)),
-			"desc-set"     => cfg.desc_set = Some(String::from(value)),
-			"name-set"     => cfg.name_set = Some(String::from(value)),
+			"acts-like" => cfg.acts_like = try!(read_byte(value)),
+			"source" => cfg.source_path = path.with_file_name(value),
+			"props" => try!(read_bytes(value, &mut cfg.tweak_bytes)),
+			"xbytes" => cfg.extra_bytes = try!(read_byte(value)),
+			"ext-props" => try!(read_bytes(value, &mut cfg.prop_bytes)),
+			"dys-opts" => try!(read_bytes(value, &mut cfg.dys_option_bytes)),
+			"ext-clip" => try!(read_bytes(value, &mut cfg.clipping)),
+			"name" => got_name = Some(String::from(value)),
+			"description" => got_desc = Some(String::from(value)),
+			"desc-set" => cfg.desc_set = Some(String::from(value)),
+			"name-set" => cfg.name_set = Some(String::from(value)),
 			"ext-prop-def" => (),
-			"m16d"         => (),
-			"tilemap"      => (),
+			"m16d" => (),
+			"tilemap" => (),
 			_ => return Err(CfgErr { explain: format!("bad field name: \"{}\"", name) }),
 		};
-	};
+	}
 
 	if let Some(s) = got_name {
 		cfg.name = s;
@@ -284,30 +308,30 @@ fn parse_newstyle(path: &Path, gen: Genus, id: u16, buf: &str) -> Result<SpriteC
 fn parse_oldstyle(path: &Path, gen: Genus, id: u16, buf: &str) -> Result<SpriteCfg, CfgErr> {
 	let mut it = buf.split_whitespace().skip(1);
 	let mut d = [0u8; 9];
-	for i in 0 .. 9 {
+	for i in 0..9 {
 		if let Some(s) = it.next() {
 			d[i] = try!(read_byte(s));
 		} else {
-			return Err(CfgErr{ explain: String::from("Old-style CFG too short") });
+			return Err(CfgErr { explain: String::from("Old-style CFG too short") });
 		}
-	};
+	}
 
 	let (name, name_set) = default_name(path, gen, id);
 	let (desc, desc_set) = (name.clone(), name_set.clone());
 
 	if let Some(s) = it.next() {
 		Ok(SpriteCfg {
-			genus:       gen,
-			id:          id,
-			acts_like:   d[0],
+			genus: gen,
+			id: id,
+			acts_like: d[0],
 			tweak_bytes: [d[1], d[2], d[3], d[4], d[5], d[6]],
-			prop_bytes:  [d[7], d[8]],
+			prop_bytes: [d[7], d[8]],
 			source_path: path.with_file_name(s),
-			name:        name,
-			name_set:    Some(name_set),
-			desc:        desc,
-			desc_set:    Some(desc_set),
-			.. SpriteCfg::new()
+			name: name,
+			name_set: Some(name_set),
+			desc: desc,
+			desc_set: Some(desc_set),
+			..SpriteCfg::new()
 		})
 	} else {
 		Err(CfgErr { explain: String::from("Old-style CFG too short") })
@@ -325,22 +349,29 @@ fn read_byte(s: &str) -> Result<u8, CfgErr> {
 			n += v;
 			read = true;
 		} else {
-			return Err(CfgErr { explain: String::from("Non-byte data in byte field") })
+			return Err(CfgErr { explain: String::from("Non-byte data in byte field") });
 		}
 	}
 
-	if !read { Err(CfgErr { explain: String::from("Expected a byte, found nothing") }) } else { Ok(n as u8) }
+	if !read {
+		Err(CfgErr { explain: String::from("Expected a byte, found nothing") })
+	} else {
+		Ok(n as u8)
+	}
 }
 
 fn read_bytes(s: &str, buf: &mut [u8]) -> Result<(), CfgErr> {
 	let mut bytes = Vec::<u8>::with_capacity(buf.len());
 	for b in s.split_whitespace() {
 		bytes.push(try!(read_byte(b)));
-	};
+	}
 
 	if bytes.len() != buf.len() {
-		Err(CfgErr { explain: format!("Wrong length byte sequence: expected {} bytes, got {}",
-		                              buf.len(), bytes.len()) })
+		Err(CfgErr {
+			explain: format!("Wrong length byte sequence: expected {} bytes, got {}",
+			                 buf.len(),
+			                 bytes.len()),
+		})
 	} else {
 		for (i, b) in bytes.iter().enumerate() {
 			buf[i] = *b;
@@ -349,8 +380,12 @@ fn read_bytes(s: &str, buf: &mut [u8]) -> Result<(), CfgErr> {
 	}
 }
 
-fn tag_ending_s(ch: char) -> bool { ch == ' ' || ch == ':' }
-fn line_ending_s(ch: char) -> bool { ch == '\r' || ch == '\n' }
+fn tag_ending_s(ch: char) -> bool {
+	ch == ' ' || ch == ':'
+}
+fn line_ending_s(ch: char) -> bool {
+	ch == '\r' || ch == '\n'
+}
 
 named!(cfg_line(&str) -> (&str, &str),
   chain!(


### PR DESCRIPTION
This fixes various code style inconsistencies.

Enabled hard tabs because it appears to be overall style of a project, and changing it to use spaces would make a huge commit.